### PR TITLE
Add TradeSight — Python backtesting + paper trading framework with Alpaca

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ We are collecting a list of resources papers, softwares, books, articles for fin
 | [vectorbt](https://github.com/polakowo/vectorbt) | vectorbt takes a novel approach to backtesting: it operates entirely on pandas and NumPy objects, and is accelerated by Numba to analyze any data at speed and scale. This allows for testing of many thousands of strategies in seconds. | ![GitHub stars](https://badgen.net/github/stars/polakowo/vectorbt) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [pysystemtrade](https://github.com/robcarver17/pysystemtrade) | Systematic Trading in python from book Systematic Trading by Rob Carver | ![GitHub stars](https://badgen.net/github/stars/robcarver17/pysystemtrade) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [bt](https://github.com/pmorissette/bt) | Flexible backtesting for Python based on Algo and Strategy Tree | ![GitHub stars](https://badgen.net/github/stars/pmorissette/bt) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
+| [TradeSight](https://github.com/rmbell09-lang/tradesight) | Python backtesting and paper trading framework with Alpaca integration, Monte Carlo simulation, and risk management tools | ![GitHub stars](https://badgen.net/github/stars/rmbell09-lang/tradesight) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 
 
 ### Cryptocurrencies


### PR DESCRIPTION
Adding [TradeSight](https://github.com/rmbell09-lang/tradesight) to the Backtesting and Live Trading section.

**What it does:**
- Python backtesting framework with event-driven simulation
- Alpaca paper trading integration for live-paper execution
- Monte Carlo simulation for strategy robustness testing
- Built-in risk management: drawdown limits, position sizing, sector correlation guard
- Daily performance reports via email digest

Fits in the Backtesting and Live Trading section alongside similar Python frameworks like backtrader, bt, and quanttrader.