### PR TITLE
Add Helium to Data Sources (General)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ We are collecting a list of resources papers, softwares, books, articles for fin
 <!-- omit in toc -->
 ### What will you find here?
 
-- [97 libraries and packages](#libraries-and-packages) for research and live trading
+- [98 libraries and packages](#libraries-and-packages) for research and live trading
 - [40+ strategies](#strategies) described by institutionals and academics
 - [55 books](#books) for beginners and professionals
 - [23 videos](#videos) and interviews
@@ -81,7 +81,7 @@ We are collecting a list of resources papers, softwares, books, articles for fin
 
 # Libraries and packages
 
-*List of **97 libraries and packages** implementing trading bots, backtesters, indicators, pricers, etc. Each library is categorized by its programming language and ordered by descending populatrity (number of stars).*
+*List of **98 libraries and packages** implementing trading bots, backtesters, indicators, pricers, etc. Each library is categorized by its programming language and ordered by descending populatrity (number of stars).*
 
 
 ## Backtesting and Live Trading
@@ -224,6 +224,7 @@ We are collecting a list of resources papers, softwares, books, articles for fin
 | [Investpy](https://github.com/alvarobartt/investpy) | Financial Data Extraction from Investing.com with Python | ![GitHub stars](https://badgen.net/github/stars/alvarobartt/investpy) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [Fundamental Analysis Data](https://github.com/JerBouma/FundamentalAnalysis) | Fully-fledged Fundamental Analysis package capable of collecting 20 years of Company Profiles, Financial Statements, Ratios and Stock Data of 20.000+ companies. | ![GitHub stars](https://badgen.net/github/stars/JerBouma/FundamentalAnalysis) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 | [Wallstreet](https://github.com/mcdallas/wallstreet) | Wallstreet: Real time Stock and Option tools | ![GitHub stars](https://badgen.net/github/stars/mcdallas/wallstreet) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
+| [Helium](https://github.com/connerlambden/helium-mcp) | Live stock, ETF, and crypto data with AI bull/bear cases and probability-weighted scenarios; ML options pricing (fair value, probability ITM, full Greeks); historical options chains for backtesting; AI-ranked trading strategies; real-time news with bias scoring for sentiment signals; MCP server or REST API. Website: [heliumtrades.com/mcp-page](https://heliumtrades.com/mcp-page/). | ![GitHub stars](https://badgen.net/github/stars/connerlambden/helium-mcp) | ![made-with-javascript](https://img.shields.io/badge/Made%20with-Javascript-1f425f.svg) |
 
 
 ### Cryptocurrencies


### PR DESCRIPTION
Adds [Helium](https://heliumtrades.com/mcp-page/) to the Data Sources → General table: live markets (stocks/ETFs/crypto) with AI bull/bear scenarios, ML options pricing and Greeks, historical options chains, AI-ranked strategies, bias-scored news for sentiment, plus [MCP](https://github.com/connerlambden/helium-mcp) / REST access. Updates the library count to 98.