### PR TITLE
Add Vigil — AI trade journal for prop firm traders

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ We are collecting a list of resources papers, softwares, books, articles for fin
 | [PyTrendFollow](https://github.com/chrism2671/PyTrendFollow) | PyTrendFollow - systematic futures trading using trend following | ![GitHub stars](https://badgen.net/github/stars/chrism2671/PyTrendFollow) | ![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg) |
 
 ## Analytics
+- [Vigil](https://runvigil.app) - AI trade journal with multi-agent audit, prop firm rule library, and trailing drawdown simulator. Free tier.
 
 ### Indicators
 


### PR DESCRIPTION
## What is Vigil?

[Vigil](https://runvigil.app) is a free, open-tier trade journal built specifically for traders dealing with prop firm rules. Unlike generic journals, Vigil pre-loads the rule sets of FTMO, TopStep, Apex, FundedNext, and 20+ other firms, then audits each trade against:

- Daily loss limits
- Trailing and static drawdown
- Behavioral patterns (revenge trading, stop-moving, overtrading)

Free tier covers 3 audits/month; Pro is $49/mo. Built by an indie team.

This entry follows the existing format under the section. Happy to adjust wording — just let me know.
